### PR TITLE
Fix non-inclusive ranges bug

### DIFF
--- a/frdconvert.py
+++ b/frdconvert.py
@@ -205,7 +205,7 @@ def _find_ranges(lines):
             starts[items[1]] = num + 1
         # Data ends with a “-3”-line.
         elif ln.startswith("-3"):
-            ends[next(reversed(starts.keys()))] = num - 1
+            ends[next(reversed(starts.keys()))] = num 
     ranges = {name: (starts[name], ends[name]) for name in starts.keys()}
     del starts, ends
     return ranges


### PR DESCRIPTION
Ranges are non-inclusive, i.e. `range(0, 3) = [0, 3)`. Because of that when data ends, one should store the line number of its end + 1

Consider the following example:
```
2C
-1         1           0           0           0
-3
```

Unmodified code produces the following result (json):
```
{
  "NODES": {

  }
}
```

Modified:
```
{
  "NODES": {
    "1": [0.0, 0.0, 0.0]
  }
}
```